### PR TITLE
optimum: return None when no valid trial is available

### DIFF
--- a/pyrameter/optimizer.py
+++ b/pyrameter/optimizer.py
@@ -196,6 +196,8 @@ class FMin(object):
         best = None
         for searchspace in self.searchspaces:
             candidate = searchspace.optimum()
+            if candidate is None:
+                continue
             if best is None or candidate.objective < best.objective:
                 best = candidate
         return best
@@ -338,7 +340,7 @@ class FMin(object):
         print(f'{total} Trials\t{pending} Pending\t{success} Successes\t{error} Errors')
         print('-------------------------------------------------------------------')
         print('\n')
-        if success > 0:
+        if success > 0 and opt:
             print('Optimal')
             print('-------------------------------------------------------------------')
             print(f'Trial {opt.id}\t{opt.objective} Loss')

--- a/pyrameter/searchspace.py
+++ b/pyrameter/searchspace.py
@@ -174,9 +174,13 @@ class SearchSpace(object, metaclass=SearchSpaceMeta):
             The trial with the optimal observed value of the objective
             function.
         """
-        return sorted([t for t in self.trials if t.objective is not None],
-                      key=lambda x: x.objective,
-                      reverse=(mode == 'max'))[0]
+        trials_sorted = sorted([t for t in self.trials if t.objective is not None],
+                key=lambda x: x.objective,
+                reverse=(mode == 'max'))
+        try:
+            return trials_sorted[0]
+        except IndexError:
+            return None
 
     def to_array(self):
         """Convert the trials in this search space into a contiguous array.


### PR DESCRIPTION
We found this one while testing the packaging of CCTools.  If no valid trial was found, then the `self.summary` of shadho failed with an IndexError. This pr makes it so that on no valid trial `None` is returned, and the summary is adapted accordingly.

